### PR TITLE
fix-artifactory-accounts

### DIFF
--- a/.circleci/continue_config.yml
+++ b/.circleci/continue_config.yml
@@ -623,7 +623,7 @@ jobs:
           at: .
       - run: pip install wheel twine
       - run: mkdir -p target/wheels && cp target/wheels/* dist/
-      - run: python -m twine upload --non-interactive --verbose -u $ARTIFACTORY_USERNAME -p $ARTIFACTORY_PASSWORD --repository-url https://datakin.jfrog.io/artifactory/api/pypi/pypi-public-libs-release dist/*
+      - run: python -m twine upload --non-interactive --verbose -u $ARTIFACTORY_USERNAME -p $ARTIFACTORY_PASSWORD --repository-url https://astronomer.jfrog.io/artifactory/api/pypi/pypi-public-libs-release dist/*
 
   release-python:
     working_directory: ~/openlineage

--- a/client/java/build.gradle
+++ b/client/java/build.gradle
@@ -179,7 +179,7 @@ publishing {
     repositories {
         maven {
             url = isReleaseVersion ? 'https://oss.sonatype.org/service/local/staging/deploy/maven2' :
-                    'https://datakin.jfrog.io/artifactory/maven-public-libs-snapshot'
+                    'https://astronomer.jfrog.io/artifactory/maven-public-libs-snapshot'
             credentials {
                 username = System.getenv('RELEASE_USERNAME')
                 password = System.getenv('RELEASE_PASSWORD')


### PR DESCRIPTION
<!-- SPDX-License-Identifier: Apache-2.0 -->

### Problem

Change the artifactory accounts used for publishing PyPI and Maven libraries.

Closes: #1138

### Solution

Created a new account and added 2 relevant local repositories to house these artifacts

### Checklist

- [x] You've [signed-off](https://github.com/OpenLineage/OpenLineage/blob/main/why-the-dco.md) your work
- [x] Your pull request title follows our [guidelines](https://github.com/OpenLineage/OpenLineage/blob/main/CONTRIBUTING.md#creating-pull-requests)
- [ ] Your changes are accompanied by tests (_if relevant_)
- [ ] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [ ] You've updated any relevant documentation (_if relevant_)
- [ ] You've updated the [`CHANGELOG.md`](https://github.com/OpenLineage/OpenLineage/blob/main/CHANGELOG.md) with details about your change under the "Unreleased" section (_if relevant, depending on the change, this may not be necessary_)
- [ ] You've versioned the core OpenLineage model or facets according to [SchemaVer](https://docs.snowplowanalytics.com/docs/pipeline-components-and-applications/iglu/common-architecture/schemaver) (_if relevant_)
- [ ] You've added a [header](https://github.com/OpenLineage/OpenLineage/tree/main/.github/header_templates.md) to source files (_if relevant_)